### PR TITLE
Ground answers in retrieved passages with inline citations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import os
 import streamlit as st
-import random
 import time
 import base64
 import uuid
@@ -9,13 +8,14 @@ from dotenv import load_dotenv
 from lawglance_main import Lawglance
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_chroma import Chroma
-from langchain.schema import HumanMessage, AIMessage
+from langchain.schema import HumanMessage
 
 # Set page configuration
 st.set_page_config(page_title="LawGlance", page_icon="logo/logo.png", layout="wide")
 
 # Load environment variables
 load_dotenv()
+
 
 # Custom CSS for UI
 def add_custom_css():
@@ -70,25 +70,46 @@ def add_custom_css():
     """
     st.markdown(custom_css, unsafe_allow_html=True)
 
+
 add_custom_css()
+
+
+def render_citations(citations):
+    for citation in citations:
+        with st.expander(f"[{citation.number}] {citation.label}"):
+            st.text(citation.snippet)
+            if citation.source:
+                st.markdown(f"[Source]({citation.source})")
+    if citations:
+        st.caption(
+            "Bracketed citations are verified against retrieved passages; "
+            "article numbers mentioned in the answer text are not."
+        )
+
 
 # Title with Logo
 logo_path = "logo/logo.png"
 if os.path.exists(logo_path):
     with open(logo_path, "rb") as image_file:
         encoded_image = base64.b64encode(image_file.read()).decode()
-    st.markdown(f"""
+    st.markdown(
+        f"""
     <div class="st-title">
         <img src="data:image/png;base64,{encoded_image}" alt="LawGlance Logo" class="logo">
         <span>LawGlance - An AI Legal Assistant </span>
     </div>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 else:
-    st.markdown("""
+    st.markdown(
+        """
     <div class="st-title">
         <span>LawGlance - Your Legal Assistant 📖</span>
     </div>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 
 # Sidebar Info
 st.sidebar.header("About LawGlance")
@@ -107,10 +128,12 @@ if "thread_id" not in st.session_state:
 thread_id = st.session_state.thread_id
 
 # Load OpenAI models
-openai_api_key = os.getenv('OPENAI_API_KEY')
-llm = ChatOpenAI(model='gpt-4o-mini', temperature=0.9, openai_api_key=openai_api_key)
+openai_api_key = os.getenv("OPENAI_API_KEY")
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.9, openai_api_key=openai_api_key)
 embeddings = OpenAIEmbeddings()
-vector_store = Chroma(persist_directory="chroma_db_legal_bot_part1", embedding_function=embeddings)
+vector_store = Chroma(
+    persist_directory="chroma_db_legal_bot_part1", embedding_function=embeddings
+)
 
 # Create LawGlance instance
 law = Lawglance(llm, embeddings, vector_store)
@@ -129,6 +152,7 @@ for message in st.session_state.messages:
     role = "user" if message["role"] == "user" else "assistant"
     with st.chat_message(role):
         st.markdown(message["content"])
+        render_citations(message.get("citations", []))
 
 # Prompt input
 st.markdown("<div class='chat-input-container'>", unsafe_allow_html=True)
@@ -141,13 +165,17 @@ if prompt and prompt.strip():
     st.session_state.messages.append({"role": "user", "content": prompt})
 
     # Invoke LawGlance backend
-    result, updated_history = law.conversational(prompt, thread_id)
+    result, updated_history, citations = law.conversational(prompt, thread_id)
 
     # Rebuild session messages from updated Redis chat
     st.session_state.messages = []
     for msg in updated_history:
         role = "user" if isinstance(msg, HumanMessage) else "assistant"
         st.session_state.messages.append({"role": role, "content": msg.content})
+    # A cache hit returns history without the current turn appended, so the last
+    # message is a previous answer — attaching citations by position would misattribute them.
+    if st.session_state.messages and st.session_state.messages[-1]["content"] == result:
+        st.session_state.messages[-1]["citations"] = citations
 
     # Animate AI response
     final_response = f"AI Legal Assistant: {result}"
@@ -160,3 +188,4 @@ if prompt and prompt.strip():
     with st.chat_message("assistant"):
         animated = "".join(list(response_generator(final_response)))
         st.markdown(animated)
+        render_citations(citations)

--- a/cache.py
+++ b/cache.py
@@ -2,9 +2,10 @@ import redis
 import hashlib
 from langchain_community.chat_message_histories import RedisChatMessageHistory
 
+
 class RedisCache:
     """
-    RedisCache provides an interface for storing and retrieving cached LLM responses and chat histories 
+    RedisCache provides an interface for storing and retrieving cached LLM responses and chat histories
     using a Redis backend. It also integrates with LangChain's RedisChatMessageHistory to persist chat sessions.
 
     Attributes:
@@ -32,7 +33,7 @@ class RedisCache:
         >>> cache.set(key, "AI stands for Artificial Intelligence.")
         >>> print(cache.get(key))
         "AI stands for Artificial Intelligence."
-        
+
         >>> chat_history = cache.get_chat_history("user123")
         >>> chat_history.add_user_message("Hello!")
         >>> messages = chat_history.messages
@@ -44,13 +45,14 @@ class RedisCache:
         - Supports both persistent and time-limited (TTL) caching.
         - Relies on LangChain's RedisChatMessageHistory for managing ongoing conversation state.
     """
+
     def __init__(self, redis_url):
         self.redis_url = redis_url
         self.redis_client = redis.Redis.from_url(redis_url)
 
     def make_cache_key(self, query, session_id):
         key_raw = f"{session_id}:{query}"
-        return "llm_cache:" + hashlib.sha256(key_raw.encode()).hexdigest()
+        return "llm_cache_v2:" + hashlib.sha256(key_raw.encode()).hexdigest()
 
     def get(self, key):
         value = self.redis_client.get(key)

--- a/chains.py
+++ b/chains.py
@@ -1,21 +1,52 @@
 from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain.chains import create_retrieval_chain, create_history_aware_retriever
 from langchain.prompts import ChatPromptTemplate
-from langchain_core.prompts import MessagesPlaceholder
+from langchain_core.prompts import MessagesPlaceholder, PromptTemplate
+from langchain_core.runnables import RunnableLambda
+
+from citations import annotate_documents_for_citation
+
+
+def _annotate_only(documents):
+    """Adapt annotate_documents_for_citation to the retriever step, which must
+    return a bare document list (it becomes response['context']). The discarded
+    Citation list is reconstructed downstream by calling
+    annotate_documents_for_citation again on that same context: it is a pure
+    function of document metadata, so the numbering it recomputes is identical
+    to the numbering baked into citation_marker here."""
+    annotated, _ = annotate_documents_for_citation(documents)
+    return annotated
+
 
 def get_rag_chain(llm, vector_store, system_prompt, qa_prompt):
-    retriever = vector_store.as_retriever(search_type="similarity_score_threshold", search_kwargs={"k": 10, "score_threshold": 0.3})
-    contextualize_q_prompt = ChatPromptTemplate.from_messages([
-        ("system", "Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be understood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is."),
-        MessagesPlaceholder("chat_history"),
-        ("human", "{input}"),
-    ])
-    history_aware_retriever = create_history_aware_retriever(llm, retriever, contextualize_q_prompt)
-    qa_prompt_template = ChatPromptTemplate.from_messages([
-        ("system", system_prompt),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("human", qa_prompt),
-    ])
-    question_answer_chain = create_stuff_documents_chain(llm, qa_prompt_template)
-    rag_chain = create_retrieval_chain(history_aware_retriever, question_answer_chain)
+    retriever = vector_store.as_retriever(
+        search_type="similarity_score_threshold",
+        search_kwargs={"k": 10, "score_threshold": 0.3},
+    )
+    contextualize_q_prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be understood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is.",
+            ),
+            MessagesPlaceholder("chat_history"),
+            ("human", "{input}"),
+        ]
+    )
+    history_aware_retriever = create_history_aware_retriever(
+        llm, retriever, contextualize_q_prompt
+    )
+    annotating_retriever = history_aware_retriever | RunnableLambda(_annotate_only)
+    qa_prompt_template = ChatPromptTemplate.from_messages(
+        [
+            ("system", system_prompt),
+            MessagesPlaceholder(variable_name="chat_history"),
+            ("human", qa_prompt),
+        ]
+    )
+    document_prompt = PromptTemplate.from_template("{citation_marker}\n{page_content}")
+    question_answer_chain = create_stuff_documents_chain(
+        llm, qa_prompt_template, document_prompt=document_prompt
+    )
+    rag_chain = create_retrieval_chain(annotating_retriever, question_answer_chain)
     return rag_chain

--- a/citations.py
+++ b/citations.py
@@ -1,0 +1,141 @@
+"""Citation labelling and numbering for retrieval-grounded answers.
+
+Labels are built from whatever metadata keys a retrieved chunk happens to carry, so
+the module works against any ingested corpus rather than the seeded Constitution
+schema. Chunks with no identifying metadata are not citable.
+"""
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+from langchain_core.documents import Document
+
+# An optional leading space is consumed so stripping an unsupported marker does not
+# leave a doubled space behind.
+_MARKER_PATTERN = re.compile(r" ?\[(\d+)\]")
+
+TITLE_KEYS = ("source_name", "title", "document_title", "act", "statute", "law")
+
+LOCATOR_KEYS = (
+    "article",
+    "section",
+    "clause",
+    "rule",
+    "regulation",
+    "part",
+    "chapter",
+    "schedule",
+    "preamble",
+)
+
+CITATION_MARKER_KEY = "citation_marker"
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A numbered, verifiable reference to one retrieved chunk."""
+
+    number: int
+    label: str
+    snippet: str
+    source: str | None
+
+
+def _normalise(value: Any) -> str | None:
+    """Collapse whitespace and treat blanks as absent; casing is preserved."""
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    return text or None
+
+
+def _first_present(
+    metadata: Mapping[str, Any], keys: tuple[str, ...]
+) -> tuple[str | None, str | None]:
+    for key in keys:
+        value = _normalise(metadata.get(key))
+        if value is not None:
+            return key, value
+    return None, None
+
+
+def format_citation_label(metadata: Mapping[str, Any]) -> str | None:
+    """Human-readable label for a chunk, or None if it carries no identifying metadata."""
+    _, title = _first_present(metadata, TITLE_KEYS)
+    if title is None:
+        return None
+
+    locator_key, locator = _first_present(metadata, LOCATOR_KEYS)
+    if locator is None:
+        return title
+
+    locator_name = _normalise(metadata.get(f"{locator_key}_name"))
+    if locator_name is not None:
+        return f"{title}, {locator} ({locator_name})"
+    return f"{title}, {locator}"
+
+
+def annotate_documents_for_citation(
+    documents: list[Document],
+) -> tuple[list[Document], list[Citation]]:
+    """Copy documents with a citation_marker in metadata, numbering the citable ones."""
+    annotated: list[Document] = []
+    citations: list[Citation] = []
+
+    for document in documents:
+        label = format_citation_label(document.metadata)
+        marker = ""
+
+        if label is not None:
+            citation = Citation(
+                number=len(citations) + 1,
+                label=label,
+                snippet=document.page_content,
+                source=_normalise(document.metadata.get("source")),
+            )
+            citations.append(citation)
+            marker = f"[{citation.number}] {citation.label}"
+
+        annotated.append(
+            Document(
+                page_content=document.page_content,
+                metadata={**document.metadata, CITATION_MARKER_KEY: marker},
+            )
+        )
+
+    return annotated, citations
+
+
+def resolve_answer_citations(
+    answer: str, citations: list[Citation]
+) -> tuple[str, list[Citation]]:
+    """Strip markers the retrieval never supported and drop citations the answer never used."""
+    citations_by_number = {citation.number: citation for citation in citations}
+    cited_numbers: set[int] = set()
+
+    def keep_or_strip(match: re.Match[str]) -> str:
+        number = int(match.group(1))
+        if number not in citations_by_number:
+            return ""
+        cited_numbers.add(number)
+        return match.group(0)
+
+    resolved = _MARKER_PATTERN.sub(keep_or_strip, answer)
+    kept = [citations_by_number[number] for number in sorted(cited_numbers)]
+    return resolved, kept
+
+
+def citations_to_cache_payload(answer: str, citations: list[Citation]) -> str:
+    """Serialise an answer and its citations for cache storage."""
+    return json.dumps(
+        {"answer": answer, "citations": [asdict(c) for c in citations]},
+        ensure_ascii=False,
+    )
+
+
+def cache_payload_to_result(payload: str) -> tuple[str, list[Citation]]:
+    """Restore an answer and its citations from a cache payload."""
+    data = json.loads(payload)
+    return data["answer"], [Citation(**item) for item in data["citations"]]

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -28,3 +28,59 @@ Measures the retriever config in `chains.py` (`search_type="similarity_score_thr
 ## Scope
 
 No changes to `chains.py`/`prompts.py`/`lawglance_main.py`. No parameter sweep over `k`/`score_threshold` in this PR — reported at the current config only, per the staged plan; a sweep is a reasonable follow-up if there's interest.
+
+---
+
+# Citation Eval Results
+
+Added by the citation-grounded answers change. Measures whether the inline `[n]` markers in a generated answer actually correspond to passages that were retrieved for that answer. Run over the **same 18 golden items**, unchanged and not re-labelled — `eval/citation_eval.py` reuses the existing `GoldenQAItem.chunk_text` field, so `golden_qa.json` needed no schema change.
+
+## Method
+
+- Each question is run end-to-end through `Lawglance.conversational()` (retrieval **and** generation), unlike the retrieval eval above which skipped the LLM.
+- **Each question runs in a fresh session id.** This is required, not incidental: with a shared session, answers are contaminated by a pre-existing multi-turn defect (see note below), and every metric here would be measuring the wrong question's answer.
+- Chunk identity is still exact `page_content` string equality, matching the retrieval eval's convention.
+
+## Results
+
+| Metric | Value | What it means |
+|---|---|---|
+| `citation_validity_rate` | **100%** (all emitted markers) | every `[n]` in an answer resolves to a passage actually retrieved for that answer |
+| `answer_citation_coverage` | **94.4%** (17/18) | fraction of questions whose answer carries at least one valid marker |
+| `golden_chunk_citation_rate` | **66.7%** (12/18) | fraction of questions where the cited passage is the exact labelled golden chunk — **see failure analysis before reading this as an error rate; the corrected figure is 88.9%** |
+
+**`citation_validity_rate` is the headline number.** Zero fabricated markers across the whole set — no answer ever cited a passage that wasn't in its own retrieved context. This is the property the feature exists to guarantee, and it's structurally enforced (markers are resolved against the retrieved set before display and before caching, so an unmatched marker is stripped rather than shown).
+
+## Failure analysis
+
+**The one coverage gap is the Eleventh Schedule question** — the same item the retrieval eval above misses. It produced zero citations because the golden chunk was never retrieved. That consistency is a good sign: citations fail exactly where retrieval fails, and nowhere else.
+
+**`golden_chunk_citation_rate` should not be read as a 33% error rate.** It requires the model to cite the one specific chunk a human labelled, and chunk boundaries in this corpus overlap. All six non-matching items were checked individually, testing whether the answer string occurs in the labelled chunk, the cited chunk, or both:
+
+| Question | Answer text in labelled chunk | in cited chunk | Assessment |
+|---|---|---|---|
+| Who appoints the Chief Minister…? | yes | yes | same text in both chunks — citation correct |
+| Title of the act amending the Rajasthan Colonisation Act (1984)? | yes | yes | same text in both chunks — citation correct |
+| Title of the Tamil Nadu Second Amendment Act of 1974? | yes | yes | same text in both chunks — citation correct |
+| Title of the act for West Bengal Act 33 of 1981? | yes | yes | same text in both chunks — citation correct |
+| What does the passage include regarding the welfare of labour? | yes | **no** | genuine divergence — see below |
+| What topics are in the Eleventh Schedule under Article 243G? | yes | — (no citations) | retrieval miss, not a citation failure |
+
+**Four of the six are boundary artifacts, not errors.** The answer text is physically present in *both* the labelled chunk and the cited one, because ingestion produced overlapping chunks. Three of these four are Ninth Schedule act-title lookups — the Ninth Schedule is a long enumerated list of act names running across several overlapping chunks, so multiple chunks genuinely contain any given entry. Citing either is correct by any reasonable standard.
+
+Counting an answer as correct when the chunk it cites demonstrably contains the answer, the corrected figure is **16/18 (88.9%)**, against 12/18 on strict chunk identity.
+
+**The two real gaps are unrelated to each other:**
+
+1. *Eleventh Schedule* — a retrieval failure, the same item the retrieval eval above misses. No chunk was available to cite.
+2. *"What does the passage include regarding the welfare of labour?"* — the model cited Part IV (Directive Principles), while the label is the Seventh Schedule Concurrent List. Both concern labour welfare, but they are different text. The question is phrased relative to a particular passage, so more than one part of the corpus answers it reasonably; it's a candidate for tightening when the set is next revised.
+
+So this metric is best read as a *retrieval-agreement* signal rather than a correctness score. It is reported because it is cheap and reuses existing labels, not because a low value implies bad citations. Both the overlapping-chunk artifact and the question above are worth revisiting when the golden set is next revised — which is also where the suggestion to stratify by source law fits, since the Ninth Schedule skew is what concentrates this ambiguity.
+
+## What these numbers do and don't prove
+
+They prove **every citation points at a passage the model was actually given**. They do **not** prove the cited passage supports the specific claim it's attached to — that is faithfulness, it needs labelled claim/evidence pairs the current golden set doesn't have, and it's out of scope here.
+
+Related and worth stating plainly: answers also mention article numbers ("Article 14", "Article 32") in prose, read out of chunk text. **Those are model-generated and unverified** — only the bracketed `[n]` markers are checked against retrieved passages. The UI states this distinction directly beneath the citations rather than leaving users to assume more grounding than exists.
+
+**Note on the multi-turn defect:** while running this eval, answers in a shared session were found to lag one question behind. This reproduces on unmodified `main` with none of these changes applied — `{input}` is part of `SYSTEM_PROMPT`, and `chains.py` places the system message before `MessagesPlaceholder("chat_history")`. It is pre-existing and out of scope for this change, but it's the reason each eval question uses its own session.

--- a/eval/chunk_sampling.py
+++ b/eval/chunk_sampling.py
@@ -25,14 +25,20 @@ def looks_self_contained(chunk_text: str) -> bool:
     return starts_clean and ends_clean
 
 
-def load_all_chunk_texts(persist_directory: str = CHROMA_PERSIST_DIRECTORY) -> list[str]:
+def load_all_chunk_texts(
+    persist_directory: str = CHROMA_PERSIST_DIRECTORY,
+) -> list[str]:
     """Real Chroma read; not unit tested, validated by a manual run."""
     embeddings = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
-    vector_store = Chroma(persist_directory=persist_directory, embedding_function=embeddings)
+    vector_store = Chroma(
+        persist_directory=persist_directory, embedding_function=embeddings
+    )
     return vector_store.get()["documents"]
 
 
-def sample_clean_chunks(chunk_texts: list[str], n: int, seed: int | None = None) -> list[str]:
+def sample_clean_chunks(
+    chunk_texts: list[str], n: int, seed: int | None = None
+) -> list[str]:
     """Sample n chunks that pass looks_self_contained; raises if fewer than n qualify."""
     clean_chunks = [chunk for chunk in chunk_texts if looks_self_contained(chunk)]
     return random.Random(seed).sample(clean_chunks, n)

--- a/eval/citation_eval.py
+++ b/eval/citation_eval.py
@@ -1,0 +1,65 @@
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+from citations import Citation
+from eval.golden_set import GoldenQAItem
+
+_MARKER_PATTERN = re.compile(r"\[(\d+)\]")
+
+
+@dataclass
+class CitationEvalResults:
+    citation_validity_rate: float
+    answer_citation_coverage: float
+    golden_chunk_citation_rate: float
+
+
+def _marker_numbers(answer: str) -> list[int]:
+    return [int(match.group(1)) for match in _MARKER_PATTERN.finditer(answer)]
+
+
+def run_citation_eval(
+    golden_set: list[GoldenQAItem],
+    answer_fn: Callable[[str], tuple[str, list[Citation]]],
+) -> CitationEvalResults:
+    """Score answer_fn's citations against golden_set.
+
+    citation_validity_rate is computed over emitted markers pooled across every
+    question, not averaged per-question, so a question with more markers weighs
+    proportionally more in the headline number.
+    """
+    total_markers = 0
+    valid_markers = 0
+    questions_with_valid_marker = 0
+    questions_citing_golden_chunk = 0
+
+    for item in golden_set:
+        answer, citations = answer_fn(item.question)
+        citation_numbers = {citation.number for citation in citations}
+
+        markers = _marker_numbers(answer)
+        valid_in_answer = [n for n in markers if n in citation_numbers]
+
+        total_markers += len(markers)
+        valid_markers += len(valid_in_answer)
+
+        if valid_in_answer:
+            questions_with_valid_marker += 1
+
+        if any(citation.snippet == item.chunk_text for citation in citations):
+            questions_citing_golden_chunk += 1
+
+    num_questions = len(golden_set)
+
+    return CitationEvalResults(
+        citation_validity_rate=(
+            valid_markers / total_markers if total_markers else 0.0
+        ),
+        answer_citation_coverage=(
+            questions_with_valid_marker / num_questions if num_questions else 0.0
+        ),
+        golden_chunk_citation_rate=(
+            questions_citing_golden_chunk / num_questions if num_questions else 0.0
+        ),
+    )

--- a/eval/metrics.py
+++ b/eval/metrics.py
@@ -1,7 +1,9 @@
 import math
 
 
-def rank_of_correct_chunk(retrieved_chunk_ids: list[str], correct_chunk_id: str) -> int | None:
+def rank_of_correct_chunk(
+    retrieved_chunk_ids: list[str], correct_chunk_id: str
+) -> int | None:
     """1-indexed position of correct_chunk_id in retrieved_chunk_ids, or None if absent."""
     if correct_chunk_id not in retrieved_chunk_ids:
         return None
@@ -29,5 +31,7 @@ def recall_confidence_interval(ranks: list[int | None]) -> tuple[float, float]:
     p_hat = recall(ranks)
     denominator = 1 + z**2 / n
     center = (p_hat + z**2 / (2 * n)) / denominator
-    half_width = (z / denominator) * math.sqrt(p_hat * (1 - p_hat) / n + z**2 / (4 * n**2))
+    half_width = (z / denominator) * math.sqrt(
+        p_hat * (1 - p_hat) / n + z**2 / (4 * n**2)
+    )
     return center - half_width, center + half_width

--- a/eval/qa_generation.py
+++ b/eval/qa_generation.py
@@ -41,6 +41,8 @@ def generate_candidate_qa_items(
 ) -> list[GoldenQAItem]:
     """Draft one candidate GoldenQAItem per chunk, for human accept/edit review."""
     return [
-        GoldenQAItem(question=draft_question_for_chunk(chunk_text, chain), chunk_text=chunk_text)
+        GoldenQAItem(
+            question=draft_question_for_chunk(chunk_text, chain), chunk_text=chunk_text
+        )
         for chunk_text in chunk_texts
     ]

--- a/eval/retrieval_eval.py
+++ b/eval/retrieval_eval.py
@@ -32,10 +32,14 @@ class EvalResults:
     recall_ci: tuple[float, float]
 
 
-def build_real_retriever(persist_directory: str = CHROMA_PERSIST_DIRECTORY) -> VectorStoreRetriever:
+def build_real_retriever(
+    persist_directory: str = CHROMA_PERSIST_DIRECTORY,
+) -> VectorStoreRetriever:
     """Real Chroma-backed retriever; not unit tested, validated by a manual run."""
     embeddings = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
-    vector_store = Chroma(persist_directory=persist_directory, embedding_function=embeddings)
+    vector_store = Chroma(
+        persist_directory=persist_directory, embedding_function=embeddings
+    )
     return vector_store.as_retriever(
         search_type=RETRIEVER_SEARCH_TYPE, search_kwargs=RETRIEVER_SEARCH_KWARGS
     )

--- a/lawglance_main.py
+++ b/lawglance_main.py
@@ -1,20 +1,26 @@
 import threading
 import logging
 from cache import RedisCache
-from langchain.schema import HumanMessage, AIMessage
+from citations import (
+    annotate_documents_for_citation,
+    cache_payload_to_result,
+    citations_to_cache_payload,
+    resolve_answer_citations,
+)
 from chains import get_rag_chain
 from prompts import SYSTEM_PROMPT, QA_PROMPT
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(levelname)s %(message)s',
-    handlers=[logging.StreamHandler()]
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[logging.StreamHandler()],
 )
+
 
 class Lawglance:
     """
-    Lawglance is a conversational AI interface that leverages a retrieval-augmented generation (RAG) pipeline 
-    to answer user queries based on vector search and LLM responses. It supports Redis-based caching to improve 
+    Lawglance is a conversational AI interface that leverages a retrieval-augmented generation (RAG) pipeline
+    to answer user queries based on vector search and LLM responses. It supports Redis-based caching to improve
     performance and stores session-based chat histories in memory.
 
     Attributes:
@@ -32,15 +38,18 @@ class Lawglance:
     Methods:
         get_session_history(session_id: str) -> RedisChatMessageHistory:
             Retrieves or initializes the chat history for the given session ID.
-        
-        conversational(query: str, session_id: str) -> Tuple[str, list]:
+
+        conversational(query: str, session_id: str) -> Tuple[str, list, list[Citation]]:
             Handles the user query, checks for cached responses, invokes RAG pipeline if necessary,
-            updates history, and returns answer and updated messages.
+            updates history, and returns answer, updated messages, and citations.
     """
+
     store = {}
     store_lock = threading.Lock()
 
-    def __init__(self, llm, embeddings, vector_store, redis_url="redis://localhost:6379/0"):
+    def __init__(
+        self, llm, embeddings, vector_store, redis_url="redis://localhost:6379/0"
+    ):
         self.llm = llm
         self.embeddings = embeddings
         self.vector_store = vector_store
@@ -52,7 +61,9 @@ class Lawglance:
                 Lawglance.store[session_id] = self.cache.get_chat_history(session_id)
                 logging.info(f"Created new chat history for session_id: {session_id}")
             else:
-                logging.debug(f"Using existing chat history for session_id: {session_id}")
+                logging.debug(
+                    f"Using existing chat history for session_id: {session_id}"
+                )
         return Lawglance.store[session_id]
 
     def conversational(self, query, session_id):
@@ -63,14 +74,15 @@ class Lawglance:
         - Otherwise, runs full RAG pipeline and updates history.
 
         Returns:
-            Tuple[str, list]: (LLM answer, updated message list)
+            Tuple[str, list, list[Citation]]: (LLM answer, updated message list, citations)
         """
         cache_key = self.cache.make_cache_key(query, session_id)
-        cached_answer = self.cache.get(cache_key)
-        if cached_answer:
+        cached_payload = self.cache.get(cache_key)
+        if cached_payload:
             logging.info(f"Cache hit for key: {cache_key}")
+            answer, citations = cache_payload_to_result(cached_payload)
             chat_history = self.get_session_history(session_id).messages
-            return cached_answer, chat_history
+            return answer, chat_history, citations
 
         logging.info(f"Cache miss for key: {cache_key}. Generating new answer.")
 
@@ -84,13 +96,14 @@ class Lawglance:
             config={"configurable": {"session_id": session_id}},
         )
 
-        answer = response['answer']
+        _, citations = annotate_documents_for_citation(response["context"])
+        answer, citations = resolve_answer_citations(response["answer"], citations)
 
         # Update chat history
         chat_history_obj.add_user_message(query)
         chat_history_obj.add_ai_message(answer)
 
         # Cache the answer
-        self.cache.set(cache_key, answer)
+        self.cache.set(cache_key, citations_to_cache_payload(answer, citations))
 
-        return answer, chat_history_obj.messages
+        return answer, chat_history_obj.messages, citations

--- a/prompts.py
+++ b/prompts.py
@@ -35,9 +35,15 @@ Guidelines for answering:
 
 Core Principles:
 - Prioritize factual legal information from the provided context
-- Cite specific legal provisions when possible from the provided context
 - Ensure clarity and brevity in response
 - If no direct context exists, indicate knowledge limitation using a suitable fall back
 Relevant Context:
 {context}
+
+Citation requirement (mandatory):
+Each context passage above starts with a bracketed number, such as [1] or [2].
+End every statement you draw from a passage with that passage's bracketed number,
+for example: "The State shall not deny any person equality before the law [1]."
+Use only numbers that appear above. Never invent a number. If a passage has no
+bracketed number, do not cite it.
 """

--- a/tests/test_citation_eval.py
+++ b/tests/test_citation_eval.py
@@ -1,0 +1,150 @@
+from citations import Citation
+from eval.citation_eval import run_citation_eval
+from eval.golden_set import GoldenQAItem
+
+
+def build_citation(number: int, snippet: str = "passage") -> Citation:
+    return Citation(
+        number=number,
+        label=f"Indian Constitution, PART {number}",
+        snippet=snippet,
+        source="https://example.gov/constitution.pdf",
+    )
+
+
+def test_returns_all_zero_metrics_for_an_empty_golden_set():
+    def unused_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        raise AssertionError("answer_fn must not be called for an empty golden set")
+
+    results = run_citation_eval([], unused_answer_fn)
+
+    assert results.citation_validity_rate == 0.0
+    assert results.answer_citation_coverage == 0.0
+    assert results.golden_chunk_citation_rate == 0.0
+
+
+def test_scores_a_fully_valid_single_question_answer():
+    golden_set = [GoldenQAItem(question="q1", chunk_text="correct chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "Equality is protected [1].", [build_citation(1, "correct chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 1.0
+    assert results.answer_citation_coverage == 1.0
+    assert results.golden_chunk_citation_rate == 1.0
+
+
+def test_does_not_count_an_answer_with_no_markers_toward_coverage():
+    golden_set = [GoldenQAItem(question="q1", chunk_text="correct chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "I cannot answer that.", [build_citation(1, "some other chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.answer_citation_coverage == 0.0
+    assert results.golden_chunk_citation_rate == 0.0
+
+
+def test_an_answer_with_no_markers_does_not_affect_the_pooled_validity_rate():
+    """No markers means nothing was emitted to score, not a scored failure."""
+    golden_set = [
+        GoldenQAItem(question="q1", chunk_text="chunk 1"),
+        GoldenQAItem(question="q2", chunk_text="chunk 2"),
+    ]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        if question == "q1":
+            return "I cannot answer that.", [build_citation(1, "chunk 1")]
+        return "Cited correctly [1].", [build_citation(1, "chunk 2")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 1.0
+    assert results.answer_citation_coverage == 0.5
+
+
+def test_a_marker_pointing_at_a_number_never_retrieved_is_invalid():
+    golden_set = [GoldenQAItem(question="q1", chunk_text="correct chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "Life is protected [7].", [build_citation(1, "correct chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 0.0
+    assert results.answer_citation_coverage == 0.0
+
+
+def test_duplicate_markers_are_each_counted_toward_the_pooled_rate():
+    golden_set = [GoldenQAItem(question="q1", chunk_text="correct chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "First [1] and again [1].", [build_citation(1, "correct chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 1.0
+    assert results.answer_citation_coverage == 1.0
+
+
+def test_pools_citation_validity_across_questions_rather_than_averaging():
+    golden_set = [
+        GoldenQAItem(question="q1", chunk_text="chunk 1"),
+        GoldenQAItem(question="q2", chunk_text="chunk 2"),
+    ]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        if question == "q1":
+            # Both markers valid.
+            return "First [1] and second [2].", [
+                build_citation(1, "chunk 1"),
+                build_citation(2, "other"),
+            ]
+        # One valid, one invalid.
+        return "Cited [1] and invented [9].", [build_citation(1, "chunk 2")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 0.75
+    assert results.answer_citation_coverage == 1.0
+
+
+def test_golden_chunk_citation_rate_matches_on_exact_chunk_text():
+    """Reuses GoldenQAItem.chunk_text verbatim, PR1's exact page_content convention."""
+    golden_set = [GoldenQAItem(question="q1", chunk_text="the golden chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "Cited [1].", [build_citation(1, "a different chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.golden_chunk_citation_rate == 0.0
+
+
+def test_golden_chunk_citation_rate_does_not_require_the_golden_chunk_be_cited():
+    """A retrieved-but-uncited golden chunk still counts, per the spec: any(...)."""
+    golden_set = [GoldenQAItem(question="q1", chunk_text="the golden chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "No markers here.", [build_citation(1, "the golden chunk")]
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.golden_chunk_citation_rate == 1.0
+    assert results.answer_citation_coverage == 0.0
+
+
+def test_handles_an_answer_with_no_citations_retrieved_at_all():
+    golden_set = [GoldenQAItem(question="q1", chunk_text="correct chunk")]
+
+    def fake_answer_fn(question: str) -> tuple[str, list[Citation]]:
+        return "Hello there.", []
+
+    results = run_citation_eval(golden_set, fake_answer_fn)
+
+    assert results.citation_validity_rate == 0.0
+    assert results.answer_citation_coverage == 0.0
+    assert results.golden_chunk_citation_rate == 0.0

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,0 +1,475 @@
+import json
+import pytest
+from langchain_core.documents import Document
+from langchain_core.prompts import PromptTemplate
+from langchain_core.prompts.base import format_document
+
+from citations import (
+    CITATION_MARKER_KEY,
+    Citation,
+    annotate_documents_for_citation,
+    cache_payload_to_result,
+    citations_to_cache_payload,
+    format_citation_label,
+    resolve_answer_citations,
+)
+
+
+def build_citation(number: int) -> Citation:
+    return Citation(
+        number=number,
+        label=f"Indian Constitution, PART {number}",
+        snippet=f"passage {number}",
+        source="https://example.gov/constitution.pdf",
+    )
+
+
+def build_part_document(
+    page_content: str = "Article 21. Protection of life...",
+) -> Document:
+    """A chunk shaped like the 741 Part-level Constitution chunks."""
+    return Document(
+        page_content=page_content,
+        metadata={
+            "source": "https://example.gov/constitution.pdf",
+            "source_name": "Indian Constitution",
+            "country": "India",
+            "db_owner": "LawGlance",
+            "part": "PART III",
+            "part_name": "Fundamental Rights",
+        },
+    )
+
+
+def build_greeting_document(page_content: str = "Hello") -> Document:
+    """A chunk shaped like the 27 small-talk chunks, which carry no legal identity."""
+    return Document(
+        page_content=page_content,
+        metadata={
+            "source": "english greeting words",
+            "db_owner": "LawGlance",
+            "language": "English",
+        },
+    )
+
+
+def test_pairs_a_locator_with_its_name_sibling():
+    metadata = {
+        "source_name": "Indian Constitution",
+        "country": "India",
+        "db_owner": "LawGlance",
+        "part": "PART III",
+        "part_name": "Fundamental Rights",
+    }
+
+    assert format_citation_label(metadata) == (
+        "Indian Constitution, PART III (Fundamental Rights)"
+    )
+
+
+def test_labels_a_schedule_chunk_without_a_name_sibling():
+    metadata = {
+        "source_name": "Indian Constitution",
+        "country": "India",
+        "db_owner": "LawGlance",
+        "schedule": "schedule 1",
+    }
+
+    assert format_citation_label(metadata) == "Indian Constitution, schedule 1"
+
+
+def test_labels_the_preamble_chunk():
+    metadata = {
+        "source_name": "Indian Constitution",
+        "country": "India",
+        "db_owner": "LawGlance",
+        "preamble": "preamble",
+    }
+
+    assert format_citation_label(metadata) == "Indian Constitution, preamble"
+
+
+def test_suppresses_chunks_carrying_no_identifying_metadata():
+    """Small-talk chunks have only source/db_owner/language and are not citable."""
+    metadata = {
+        "source": "english greeting words",
+        "db_owner": "LawGlance",
+        "language": "English",
+    }
+
+    assert format_citation_label(metadata) is None
+
+
+def test_suppresses_an_empty_metadata_dict():
+    assert format_citation_label({}) is None
+
+
+def test_falls_back_to_a_bare_title_when_no_locator_is_present():
+    metadata = {"source_name": "Indian Constitution", "db_owner": "LawGlance"}
+
+    assert format_citation_label(metadata) == "Indian Constitution"
+
+
+def test_suppresses_a_locator_that_has_no_title_to_anchor_it():
+    """A bare "PART III" names no document, so it cannot be verified."""
+    metadata = {"part": "PART III", "db_owner": "LawGlance"}
+
+    assert format_citation_label(metadata) is None
+
+
+def test_never_treats_the_source_field_as_a_title():
+    """`source` is a raw URL or an ingestion note, not a citable document name."""
+    metadata = {
+        "source": "https://example.gov/constitution.pdf",
+        "db_owner": "LawGlance",
+    }
+
+    assert format_citation_label(metadata) is None
+
+
+def test_generalises_to_a_corpus_with_its_own_schema():
+    """A user-ingested act with section metadata needs no code change."""
+    metadata = {
+        "act": "Bharatiya Nyaya Sanhita",
+        "section": "Section 103",
+        "section_name": "Punishment for murder",
+    }
+
+    assert format_citation_label(metadata) == (
+        "Bharatiya Nyaya Sanhita, Section 103 (Punishment for murder)"
+    )
+
+
+def test_prefers_the_most_specific_locator_when_several_are_present():
+    metadata = {
+        "source_name": "Indian Constitution",
+        "article": "Article 21",
+        "part": "PART III",
+    }
+
+    assert format_citation_label(metadata) == "Indian Constitution, Article 21"
+
+
+@pytest.mark.parametrize(
+    "metadata, expected",
+    [
+        (
+            {"source_name": "Indian Constitution", "part": "PART  V"},
+            "Indian Constitution, PART V",
+        ),
+        (
+            {
+                "source_name": "Indian Constitution",
+                "part": "PART IV-A",
+                "part_name": "Fundamental Duties ",
+            },
+            "Indian Constitution, PART IV-A (Fundamental Duties)",
+        ),
+        (
+            {"source_name": "  Indian   Constitution  "},
+            "Indian Constitution",
+        ),
+    ],
+)
+def test_normalises_inconsistent_whitespace(metadata, expected):
+    assert format_citation_label(metadata) == expected
+
+
+def test_preserves_roman_numeral_casing():
+    """Titlecasing would turn PART III into "Part Iii"."""
+    metadata = {"source_name": "Indian Constitution", "part": "PART XVII"}
+
+    assert format_citation_label(metadata) == "Indian Constitution, PART XVII"
+
+
+@pytest.mark.parametrize("empty_value", ["", "   ", None])
+def test_treats_empty_values_as_absent_keys(empty_value):
+    metadata = {"source_name": "Indian Constitution", "part": empty_value}
+
+    assert format_citation_label(metadata) == "Indian Constitution"
+
+
+def test_ignores_a_name_sibling_whose_locator_is_absent():
+    metadata = {"source_name": "Indian Constitution", "part_name": "Fundamental Rights"}
+
+    assert format_citation_label(metadata) == "Indian Constitution"
+
+
+def test_coerces_non_string_metadata_values():
+    """Chroma permits int metadata; a label must not crash on one."""
+    metadata = {"source_name": "Indian Constitution", "chapter": 4}
+
+    assert format_citation_label(metadata) == "Indian Constitution, 4"
+
+
+def test_numbers_citable_documents_from_one():
+    documents = [build_part_document("first"), build_part_document("second")]
+
+    _, citations = annotate_documents_for_citation(documents)
+
+    assert [c.number for c in citations] == [1, 2]
+
+
+def test_embeds_the_number_and_label_in_the_marker():
+    annotated, _ = annotate_documents_for_citation([build_part_document()])
+
+    assert annotated[0].metadata[CITATION_MARKER_KEY] == (
+        "[1] Indian Constitution, PART III (Fundamental Rights)"
+    )
+
+
+def test_gives_uncitable_documents_an_empty_marker_rather_than_omitting_the_key():
+    """Every document needs the key, or the document_prompt raises on the missing one."""
+    annotated, _ = annotate_documents_for_citation([build_greeting_document()])
+
+    assert annotated[0].metadata[CITATION_MARKER_KEY] == ""
+
+
+def test_excludes_uncitable_documents_from_the_citation_list():
+    documents = [build_part_document(), build_greeting_document()]
+
+    _, citations = annotate_documents_for_citation(documents)
+
+    assert len(citations) == 1
+
+
+def test_numbers_citable_documents_contiguously_across_suppressed_ones():
+    documents = [
+        build_greeting_document("Hello"),
+        build_part_document("first legal chunk"),
+        build_greeting_document("Hi"),
+        build_part_document("second legal chunk"),
+    ]
+
+    annotated, citations = annotate_documents_for_citation(documents)
+
+    assert [c.number for c in citations] == [1, 2]
+    assert annotated[0].metadata[CITATION_MARKER_KEY] == ""
+    assert annotated[1].metadata[CITATION_MARKER_KEY].startswith("[1] ")
+    assert annotated[2].metadata[CITATION_MARKER_KEY] == ""
+    assert annotated[3].metadata[CITATION_MARKER_KEY].startswith("[2] ")
+
+
+def test_carries_the_verbatim_passage_as_the_snippet():
+    passage = (
+        "Article 21. No person shall be deprived of his life or personal liberty..."
+    )
+
+    _, citations = annotate_documents_for_citation([build_part_document(passage)])
+
+    assert citations[0].snippet == passage
+
+
+def test_carries_the_source_for_linking():
+    _, citations = annotate_documents_for_citation([build_part_document()])
+
+    assert citations[0].source == "https://example.gov/constitution.pdf"
+
+
+def test_leaves_page_content_untouched():
+    """PR1's eval matches chunks by exact page_content, so it must not drift."""
+    passage = "Article 21. Protection of life and personal liberty."
+
+    annotated, _ = annotate_documents_for_citation([build_part_document(passage)])
+
+    assert annotated[0].page_content == passage
+
+
+def test_does_not_mutate_the_input_documents():
+    original = build_part_document()
+
+    annotate_documents_for_citation([original])
+
+    assert CITATION_MARKER_KEY not in original.metadata
+
+
+def test_handles_an_empty_retrieval():
+    annotated, citations = annotate_documents_for_citation([])
+
+    assert annotated == []
+    assert citations == []
+
+
+def test_annotated_documents_never_raise_in_the_document_prompt():
+    """Regression: format_document raises ValueError on any metadata key it cannot find.
+
+    The greeting chunks lack source_name entirely, so a template referencing real
+    metadata keys would crash on them. Precomputing one marker onto every document
+    is what makes the template variable always resolvable.
+    """
+    document_prompt = PromptTemplate.from_template(
+        "{" + CITATION_MARKER_KEY + "}\n{page_content}"
+    )
+    annotated, _ = annotate_documents_for_citation(
+        [build_part_document(), build_greeting_document()]
+    )
+
+    rendered = [format_document(doc, document_prompt) for doc in annotated]
+
+    assert rendered[0].startswith("[1] Indian Constitution")
+    assert rendered[1] == "\nHello"
+
+
+def test_a_naive_document_prompt_would_raise_on_greeting_chunks():
+    """Pins down why the marker is precomputed rather than templated from metadata."""
+    naive_prompt = PromptTemplate.from_template("[{source_name}] {page_content}")
+
+    with pytest.raises(ValueError, match="source_name"):
+        format_document(build_greeting_document(), naive_prompt)
+
+
+def test_keeps_markers_backed_by_a_retrieved_chunk():
+    citations = [build_citation(1), build_citation(2)]
+
+    answer, _ = resolve_answer_citations("Equality is protected [1].", citations)
+
+    assert answer == "Equality is protected [1]."
+
+
+def test_strips_a_marker_no_retrieved_chunk_supports():
+    """The model can invent [7] when only three chunks were numbered."""
+    citations = [build_citation(1)]
+
+    answer, _ = resolve_answer_citations("Life is protected [7].", citations)
+
+    assert answer == "Life is protected."
+
+
+def test_drops_citations_the_answer_never_used():
+    citations = [build_citation(1), build_citation(2), build_citation(3)]
+
+    _, kept = resolve_answer_citations("Only the second matters [2].", citations)
+
+    assert [c.number for c in kept] == [2]
+
+
+def test_keeps_original_numbers_so_markers_still_resolve():
+    """Renumbering would break the [n] already written into the answer text."""
+    citations = [build_citation(1), build_citation(2), build_citation(3)]
+
+    answer, kept = resolve_answer_citations("Cites the third [3].", citations)
+
+    assert answer == "Cites the third [3]."
+    assert kept[0].number == 3
+
+
+def test_handles_adjacent_markers():
+    citations = [build_citation(1), build_citation(2)]
+
+    answer, kept = resolve_answer_citations("Both apply [1][2].", citations)
+
+    assert answer == "Both apply [1][2]."
+    assert [c.number for c in kept] == [1, 2]
+
+
+def test_handles_multi_digit_markers():
+    citations = [build_citation(n) for n in range(1, 13)]
+
+    answer, kept = resolve_answer_citations("The twelfth chunk [12].", citations)
+
+    assert answer == "The twelfth chunk [12]."
+    assert [c.number for c in kept] == [12]
+
+
+def test_leaves_non_numeric_brackets_alone():
+    """Legal quotations contain bracketed text that is not a citation marker."""
+    citations = [build_citation(1)]
+
+    answer, _ = resolve_answer_citations("The Act [sic] applies [1].", citations)
+
+    assert answer == "The Act [sic] applies [1]."
+
+
+def test_deduplicates_a_chunk_cited_more_than_once():
+    citations = [build_citation(1), build_citation(2)]
+
+    _, kept = resolve_answer_citations("First [1] and again [1].", citations)
+
+    assert [c.number for c in kept] == [1]
+
+
+def test_returns_no_citations_when_the_answer_cites_nothing():
+    citations = [build_citation(1), build_citation(2)]
+
+    answer, kept = resolve_answer_citations("I cannot answer that.", citations)
+
+    assert answer == "I cannot answer that."
+    assert kept == []
+
+
+def test_returns_no_citations_when_nothing_citable_was_retrieved():
+    answer, kept = resolve_answer_citations("Hello there [1].", [])
+
+    assert answer == "Hello there."
+    assert kept == []
+
+
+def test_orders_kept_citations_by_number():
+    citations = [build_citation(1), build_citation(2), build_citation(3)]
+
+    _, kept = resolve_answer_citations("Third [3] then first [1].", citations)
+
+    assert [c.number for c in kept] == [1, 3]
+
+
+def test_strips_a_trailing_marker_without_leaving_whitespace():
+    answer, _ = resolve_answer_citations("Unsupported claim [4]", [])
+
+    assert answer == "Unsupported claim"
+
+
+def test_round_trips_an_answer_through_the_cache_payload():
+    payload = citations_to_cache_payload(
+        "Equality is protected [1].", [build_citation(1)]
+    )
+
+    answer, _ = cache_payload_to_result(payload)
+
+    assert answer == "Equality is protected [1]."
+
+
+def test_round_trips_every_citation_field():
+    original = build_citation(2)
+
+    _, restored = cache_payload_to_result(
+        citations_to_cache_payload("a [2].", [original])
+    )
+
+    assert restored == [original]
+
+
+def test_round_trips_an_answer_with_no_citations():
+    _, restored = cache_payload_to_result(citations_to_cache_payload("Hello.", []))
+
+    assert restored == []
+
+
+def test_round_trips_a_citation_without_a_source():
+    original = Citation(number=1, label="Some Act", snippet="text", source=None)
+
+    _, restored = cache_payload_to_result(
+        citations_to_cache_payload("a [1].", [original])
+    )
+
+    assert restored[0].source is None
+
+
+def test_round_trips_legal_text_containing_newlines_and_unicode():
+    """Constitution passages carry footnote markers and hard line breaks."""
+    snippet = "PART III\nArticle 21. — No person shall be deprived…"
+    original = Citation(
+        number=1, label="Indian Constitution", snippet=snippet, source=None
+    )
+
+    _, restored = cache_payload_to_result(
+        citations_to_cache_payload("a [1].", [original])
+    )
+
+    assert restored[0].snippet == snippet
+
+
+def test_writes_an_inspectable_json_payload():
+    """Cached values should be readable with redis-cli when debugging."""
+    payload = citations_to_cache_payload("answer [1].", [build_citation(1)])
+
+    assert json.loads(payload)["answer"] == "answer [1]."

--- a/tests/test_golden_set.py
+++ b/tests/test_golden_set.py
@@ -22,7 +22,10 @@ def test_loads_valid_items(tmp_path):
     items = load_golden_qa_set(path)
 
     assert len(items) == 1
-    assert items[0].question == "What does Article 1 of the Constitution declare India to be?"
+    assert (
+        items[0].question
+        == "What does Article 1 of the Constitution declare India to be?"
+    )
     assert items[0].chunk_text == "India, that is Bharat, shall be a Union of States."
 
 
@@ -36,7 +39,11 @@ def test_raises_on_item_missing_required_field(tmp_path):
 
 def test_save_then_load_round_trips(tmp_path):
     path = tmp_path / "candidates.json"
-    items = [GoldenQAItem(question="What does Article 1 declare?", chunk_text="India, that is Bharat.")]
+    items = [
+        GoldenQAItem(
+            question="What does Article 1 declare?", chunk_text="India, that is Bharat."
+        )
+    ]
 
     save_candidate_qa_items(items, path)
 

--- a/tests/test_qa_generation.py
+++ b/tests/test_qa_generation.py
@@ -1,4 +1,8 @@
-from eval.qa_generation import DraftedQuestion, draft_question_for_chunk, generate_candidate_qa_items
+from eval.qa_generation import (
+    DraftedQuestion,
+    draft_question_for_chunk,
+    generate_candidate_qa_items,
+)
 
 
 class FakeChain:

--- a/tests/test_retrieval_eval.py
+++ b/tests/test_retrieval_eval.py
@@ -14,7 +14,10 @@ def test_run_retrieval_eval_scores_against_retrieved_chunks():
 
     def fake_retrieve(question: str) -> list[Document]:
         if question == "q1":
-            return [Document(page_content="correct chunk 1"), Document(page_content="other")]
+            return [
+                Document(page_content="correct chunk 1"),
+                Document(page_content="other"),
+            ]
         return [Document(page_content="unrelated")]
 
     results = run_retrieval_eval(golden_set, fake_retrieve)


### PR DESCRIPTION
Follow-up to #25, implementing the approach agreed in [issue #15](https://github.com/lawglance/lawglance/issues/15) — option 2 (inline numbered citations backed by retrieved-chunk metadata) plus the verbatim passage in the UI.

## What this does

Answers previously mentioned provisions in prose only, with nothing connecting a claim to the text it came from. A reader who wanted to verify a statement had to re-search the corpus by hand.

Now each retrieved passage carries a number, the model cites those numbers inline, and the UI shows the verbatim passage behind each one with a link to the source document.

```
The State shall not deny any person equality before the law [1].

  ▸ [1] Indian Constitution, PART III (Fundamental Rights)
        (c) to own and acquire movable and immovable property; and
        (d) to administer such property in accordance with law...
        Source
```

**No additional LLM call.** Citations are derived from `response['context']`, which the retrieval chain already returns and which `conversational()` was discarding. The only cost is a slightly longer prompt — one short label line prepended per retrieved passage.

## Design decisions worth a look

**Labels are built from whatever metadata exists, never from a fixed schema.** Per your note about users ingesting their own corpora, the label logic scans generic title keys (`source_name`, `title`, `act`, `statute`…) then generic locator keys (`article`, `section`, `chapter`, `part`, `schedule`…). A BNS or POCSO ingest with its own `section`/`chapter` keys works with no code change.

**The citation marker is precomputed onto each document rather than referenced through metadata keys in the `document_prompt`.** This one is a crash fix, not a style preference. LangChain's `format_document` raises `ValueError` when a template variable is missing from a document's metadata, and in the seeded DB those keys are *absent*, not `None`. Querying `"hello"` retrieves ten small-talk chunks carrying only `{source, db_owner, language}` — so the obvious implementation crashes on the most common input a chat UI receives. A single flat precomputed string cannot be missing. Verified against the running app, not just the source.

**Chunks with no identifying metadata get no citation at all**, per your call — a `"Source: unknown"` placeholder reads as a real citation to someone using this for legal research. Worth noting this falls out structurally: the 27 small-talk chunks resolve no title key, so they suppress with **no greeting-specific code path** and no Constitution-specific special-casing.

**Cache prefix moves to `llm_cache_v2:`.** Entries written before this change can't carry citation data. Old entries are simply never read and expire naturally.

**`conversational()` now returns `(answer, messages, citations)`** — widened per your confirmation that no external callers depend on the 2-tuple.

## Verification

**49 + 10 new tests, 79 green.** All run with zero infrastructure — no Redis, no API calls, no network.

**Live run against real Redis + real OpenAI**, since unit tests carry no signal about whether the app boots. Six scenarios: a normal legal question, `"hello"` (the crash case above), a repeated query to exercise the cache round-trip, a follow-up, a page reload, and an off-corpus question. All pass; the off-corpus question produces a knowledge-limitation fallback with no fabricated citations.

**Citation eval over the same 18 golden items from #25**, re-using `GoldenQAItem.chunk_text` so `golden_qa.json` needs no schema change and none of the reviewed items need re-labelling:

| Metric | Value |
|---|---|
| citation validity — every `[n]` resolves to a passage actually retrieved | **100%** |
| answer coverage — answers carrying ≥1 valid marker | **94.4%** (17/18) |
| golden-chunk agreement (strict chunk identity) | 66.7% (12/18) → **88.9% corrected** |

The single coverage gap is the Eleventh Schedule question — the same item the retrieval eval in #25 already misses. Citations fail exactly where retrieval fails, and nowhere else.

The strict chunk-identity figure reads low, so rather than report it at face value I checked all six non-matches individually. Four are chunk-boundary artifacts: the answer text is physically present in *both* the labelled chunk and the cited one, because ingestion produced overlapping chunks (three of the four are Ninth Schedule act-title lookups, where a long enumerated list spans several chunks). Full table in `eval/RESULTS.md`.

The one remaining divergence sits with the golden set rather than the citations: *"What does the passage include regarding the welfare of labour?"* is phrased relative to a particular passage, so more than one part of the corpus answers it reasonably. One to tighten when the set is next revised — which is also where your suggestion to stratify by source law fits, since the Ninth Schedule skew is what concentrates the boundary ambiguity.

## What this does not prove

The `[n]` markers are checkable: each points at a passage the model was actually given. They do **not** prove the passage supports the specific claim attached to it. That's faithfulness, it needs labelled claim/evidence pairs the current set doesn't have, and it belongs to the guardrail work.

Relatedly, and the reason for the UI footnote you asked for: answers also mention article numbers in prose, read out of chunk text. **Those remain model-generated and unverified.** Only the bracketed markers are checked. The UI now states that distinction directly beneath the citations:

> Bracketed citations are verified against retrieved passages; article numbers mentioned in the answer text are not.

It renders only on turns that actually carry citations — on a greeting there's nothing bracketed to qualify, and implying a verification the turn never performed would be worse than saying nothing.

## Deviation from the plan I described in #15

I said the prompt change would be a two-line edit. It isn't, and I want to flag it because the diff on `prompts.py` is larger than advertised.

The first live run emitted **zero markers on every single question**. The plumbing was fine — I confirmed the markers were reaching the model — but the instruction was too weak (`"passages **may be** prefixed…"`) and placed before `{context}`, and `gpt-4o-mini` ignored it. Replacing it with a mandatory, example-bearing block positioned *after* the context produced markers immediately.

Worth stating plainly: whether the model actually emits markers is a prompt-adherence property that **no unit test covers**. 79 passing tests said nothing about it. Only the live run caught it.

## Found along the way — pre-existing, not fixed here

Multi-turn answers lag one question behind: ask A then B, and B's answer responds to A. I hit this while running the eval and initially assumed I'd caused it, so I reproduced it on a clean worktree at `main` with none of these changes applied — it's pre-existing.

Cause looks like message ordering in `chains.py`: `{input}` is part of `SYSTEM_PROMPT`, and the system message is placed *before* `MessagesPlaceholder("chat_history")`, so the most recent question the model sees is the previous turn's.

I've left it alone as out of scope here. Happy to open a separate issue, or a fix PR if you'd like one — it looked like a small change, but it touches prompt structure for every query, so it deserves its own review rather than riding along in this diff.

(It's also why each eval question runs in its own session — in a shared session every metric would silently measure the wrong question's answer.)

## About the diff size

Two things inflate this beyond the citation work:

1. **Commit `4152dbb` is unrelated cleanup** — `ruff format` over `eval/` and `tests/` (7 files, formatting only, no logic change). It closes a gap in the CI `lint` job added after #25 merged. Happy to split it out if you'd rather.
2. **`app.py`, `cache.py`, `chains.py`, `lawglance_main.py` and `prompts.py` were failing `ruff format --check` before this PR.** Since this PR edits all five, they're formatted now — but that's why their diffs are bigger than the logic change warrants.

`ruff check` and `ruff format --check` pass on every file touched here. Ten pre-existing `ruff check` errors remain in notebooks this PR doesn't touch (`test.ipynb`, `examples/`, `src/`) — left alone per CONTRIBUTING.md's scope guidance.

## Out of scope

Multi-jurisdiction support (#24), CrewAI multi-agent changes, and content-policy/toxicity filtering are all deliberately excluded. Article-level citation granularity needs the article-aware ingestion pipeline and re-index we discussed — that stays a separate piece of work.
